### PR TITLE
feat: Add ArmorType and Shield systems with Maven wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,10 @@ dist/
 ehthumbs.db
 Thumbs.db
 
-# Maven
-.mvn/
-mvnw
-mvnw.cmd
+# Maven (excluding wrapper files which should be committed)
+# .mvn/ - keep wrapper files
+# mvnw - keep wrapper script  
+# mvnw.cmd - keep wrapper script
 
 # Gradle
 .gradle/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/README.md
+++ b/README.md
@@ -18,12 +18,7 @@ Before running this application, ensure you have the following installed:
   - Download from [Oracle](https://www.oracle.com/java/technologies/javase-downloads.html) or [OpenJDK](https://openjdk.org/)
   - Verify installation: `java -version`
 
-- **Apache Maven 3.6 or higher**
-  - Download from [Maven Downloads](https://maven.apache.org/download.cgi)
-  - **macOS**: Install with Homebrew: `brew install maven`
-  - **Windows**: Use Chocolatey: `choco install maven` or download manually
-  - **Linux**: Use package manager: `sudo apt install maven` (Ubuntu/Debian)
-  - Verify installation: `mvn -version`
+**Note**: Maven is NOT required! This project includes a Maven wrapper that automatically downloads the correct Maven version.
 
 ## 🛠️ Installation & Setup
 
@@ -36,29 +31,28 @@ cd mech-builder-and-player
 ### 2. Build the Project
 ```bash
 # Compile the project and download dependencies
-mvn clean compile
+./mvnw clean compile
 
-# Run tests (when available)
-mvn test
+# Run tests
+./mvnw test
 
 # Package the application into a JAR file
-mvn package
+./mvnw package
 ```
+
+**Windows users**: Replace `./mvnw` with `mvnw.cmd` in all commands above.
 
 ## ▶️ Running the Application
 
-### Option 1: Run with Maven (Recommended)
+### Option 1: Run with Maven Wrapper (Recommended)
 ```bash
-# Run the unified UI version
-mvn exec:java
-
-# Run the original UI version
-mvn exec:java -P ui-v1
+# Run the application
+./mvnw exec:java
 ```
 
 ### Option 2: Run from JAR
 ```bash
-# After running mvn package, use the fat JAR with all dependencies
+# After running ./mvnw package, use the fat JAR with all dependencies
 java -jar target/mech-builder-and-player-1.0.0-SNAPSHOT-jar-with-dependencies.jar
 ```
 
@@ -113,12 +107,12 @@ To add new mechs or weapons:
 
 1. **New Mech Chassis**: Edit `src/main/resources/Mech Loadout Data.csv`
 2. **New Weapons**: Edit `src/main/resources/Weaponry Components.csv`
-3. **Rebuild**: Run `mvn clean compile` to incorporate changes
+3. **Rebuild**: Run `./mvnw clean compile` to incorporate changes
 
 ### Building for Distribution
 ```bash
 # Create a fat JAR with all dependencies included
-mvn clean package
+./mvnw clean package
 
 # The executable JAR will be created at:
 # target/mech-builder-and-player-1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -130,24 +124,24 @@ mvn clean package
 
 **"Resource not found" Error**
 - Ensure CSV files are in `src/main/resources/`
-- Rebuild the project: `mvn clean compile`
+- Rebuild the project: `./mvnw clean compile`
 
 **Java Version Issues**
 - Verify Java 11+ is installed: `java -version`
 - Check JAVA_HOME environment variable
 
-**Maven Build Failures**
-- Ensure Maven is properly installed: `mvn -version`
-- Clear Maven cache: `mvn dependency:purge-local-repository`
+**Build Failures**
+- Try cleaning and rebuilding: `./mvnw clean compile`
+- Clear Maven cache: `./mvnw dependency:purge-local-repository`
 
 **Application Won't Start**
 - Check console output for specific error messages
-- Ensure all dependencies are resolved: `mvn dependency:tree`
+- Ensure all dependencies are resolved: `./mvnw dependency:tree`
 
 ### Getting Help
 1. Check the console output for detailed error messages
 2. Verify all prerequisites are installed correctly
-3. Try running `mvn clean compile` to refresh dependencies
+3. Try running `./mvnw clean compile` to refresh dependencies
 
 ## 🏗️ Architecture
 

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -127,25 +127,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <!-- Additional execution profiles for different main classes -->
-    <profiles>
-        <profile>
-            <id>ui-v1</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <configuration>
-                            <mainClass>com.mechbuilder.ui.MechBuilderUI</mainClass>
-                            <includeProjectDependencies>true</includeProjectDependencies>
-                            <includePluginDependencies>false</includePluginDependencies>
-                            <classpathScope>compile</classpathScope>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/com/mechbuilder/data/ArmorTypeRepository.java
+++ b/src/main/java/com/mechbuilder/data/ArmorTypeRepository.java
@@ -1,0 +1,94 @@
+package com.mechbuilder.data;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
+import com.mechbuilder.model.ArmorType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for loading and managing armor type data from CSV file.
+ */
+public class ArmorTypeRepository {
+    private static final String RESOURCE_PATH = "Armor Types.csv";
+    
+    public List<ArmorType> loadAll() throws IOException, CsvValidationException {
+        List<ArmorType> armorTypes = new ArrayList<>();
+        
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(RESOURCE_PATH);
+        if (inputStream == null) {
+            throw new IOException("Resource not found: " + RESOURCE_PATH);
+        }
+        
+        try (CSVReader reader = new CSVReader(new InputStreamReader(inputStream))) {
+            String[] header = reader.readNext(); // Skip header row
+            if (header == null) {
+                throw new IOException("CSV file is empty or improperly formatted.");
+            }
+
+            while (true) {
+                String[] row = reader.readNext();
+                if (row == null) break;
+                
+                if (row.length < 3) continue; // Make sure there are enough columns
+                
+                try {
+                    String armorType = row[0].trim();
+                    int hpPerTon = Integer.parseInt(row[1].trim());
+                    String type = row[2].trim();
+                    
+                    // Skip empty rows
+                    if (armorType.isEmpty()) continue;
+                    
+                    ArmorType armor = new ArmorType(armorType, hpPerTon, type);
+                    armorTypes.add(armor);
+                } catch (NumberFormatException e) {
+                    // Skip malformed rows
+                    System.err.println("Skipping malformed armor row: " + String.join(",", row));
+                }
+            }
+        }
+        
+        return armorTypes;
+    }
+    
+    /**
+     * Find armor type by name
+     */
+    public Optional<ArmorType> findByName(String name) throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(armor -> armor.getArmorType().equalsIgnoreCase(name))
+                .findFirst();
+    }
+    
+    /**
+     * Find armor types by category (Plate, Refractive, Ablative)
+     */
+    public List<ArmorType> findByType(String type) throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(armor -> armor.getType().equalsIgnoreCase(type))
+                .toList();
+    }
+    
+    /**
+     * Find armor types within HP/Ton range
+     */
+    public List<ArmorType> findByHpPerTonRange(int minHp, int maxHp) throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(armor -> armor.getHpPerTon() >= minHp && armor.getHpPerTon() <= maxHp)
+                .toList();
+    }
+    
+    /**
+     * Get the best armor type (highest HP/Ton) for a given category
+     */
+    public Optional<ArmorType> getBestArmorByType(String type) throws IOException, CsvValidationException {
+        return findByType(type).stream()
+                .max((a1, a2) -> Integer.compare(a1.getHpPerTon(), a2.getHpPerTon()));
+    }
+}

--- a/src/main/java/com/mechbuilder/data/ShieldRepository.java
+++ b/src/main/java/com/mechbuilder/data/ShieldRepository.java
@@ -1,0 +1,117 @@
+package com.mechbuilder.data;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
+import com.mechbuilder.model.Shield;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for loading and managing shield data from CSV file.
+ */
+public class ShieldRepository {
+    private static final String RESOURCE_PATH = "Shields.csv";
+    
+    public List<Shield> loadAll() throws IOException, CsvValidationException {
+        List<Shield> shields = new ArrayList<>();
+        
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(RESOURCE_PATH);
+        if (inputStream == null) {
+            throw new IOException("Resource not found: " + RESOURCE_PATH);
+        }
+        
+        try (CSVReader reader = new CSVReader(new InputStreamReader(inputStream))) {
+            String[] header = reader.readNext(); // Skip header row
+            if (header == null) {
+                throw new IOException("CSV file is empty or improperly formatted.");
+            }
+
+            while (true) {
+                String[] row = reader.readNext();
+                if (row == null) break;
+                
+                if (row.length < 7) continue; // Make sure there are enough columns
+                
+                try {
+                    String shield = row[0].trim();
+                    int hp = Integer.parseInt(row[1].trim());
+                    int rechargeRate = Integer.parseInt(row[2].trim());
+                    int rechargeDelay = Integer.parseInt(row[3].trim());
+                    double tonnage = Double.parseDouble(row[4].trim());
+                    int heatGenerated = Integer.parseInt(row[5].trim());
+                    int rechargingHeat = Integer.parseInt(row[6].trim());
+                    
+                    // Skip empty rows
+                    if (shield.isEmpty()) continue;
+                    
+                    Shield shieldObj = new Shield(shield, hp, rechargeRate, rechargeDelay, 
+                                                tonnage, heatGenerated, rechargingHeat);
+                    shields.add(shieldObj);
+                } catch (NumberFormatException e) {
+                    // Skip malformed rows
+                    System.err.println("Skipping malformed shield row: " + String.join(",", row));
+                }
+            }
+        }
+        
+        return shields;
+    }
+    
+    /**
+     * Find shield by name
+     */
+    public Optional<Shield> findByName(String name) throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(shield -> shield.getShield().equalsIgnoreCase(name))
+                .findFirst();
+    }
+    
+    /**
+     * Find shields within tonnage range
+     */
+    public List<Shield> findByTonnageRange(double minTonnage, double maxTonnage) throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(shield -> shield.getTonnage() >= minTonnage && shield.getTonnage() <= maxTonnage)
+                .toList();
+    }
+    
+    /**
+     * Find shields within HP range
+     */
+    public List<Shield> findByHpRange(int minHp, int maxHp) throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(shield -> shield.getHp() >= minHp && shield.getHp() <= maxHp)
+                .toList();
+    }
+    
+    /**
+     * Get shields excluding "None" option
+     */
+    public List<Shield> findActualShields() throws IOException, CsvValidationException {
+        return loadAll().stream()
+                .filter(shield -> !shield.isNoneShield())
+                .toList();
+    }
+    
+    /**
+     * Get the most efficient shield (highest HP per ton ratio)
+     */
+    public Optional<Shield> getMostEfficientShield() throws IOException, CsvValidationException {
+        return findActualShields().stream()
+                .max((s1, s2) -> Double.compare(s1.getEfficiencyRating(), s2.getEfficiencyRating()));
+    }
+    
+    /**
+     * Get shields sorted by efficiency (HP per ton)
+     */
+    public List<Shield> findShieldsByEfficiency() throws IOException, CsvValidationException {
+        return findActualShields().stream()
+                .sorted((s1, s2) -> Double.compare(s2.getEfficiencyRating(), s1.getEfficiencyRating()))
+                .toList();
+    }
+}

--- a/src/main/java/com/mechbuilder/model/ArmorType.java
+++ b/src/main/java/com/mechbuilder/model/ArmorType.java
@@ -1,0 +1,63 @@
+package com.mechbuilder.model;
+
+/**
+ * Represents an armor type with its specifications.
+ * Loaded from Armor Types.csv
+ */
+public class ArmorType {
+    private final String armorType;
+    private final int hpPerTon;
+    private final String type;
+
+    public ArmorType(String armorType, int hpPerTon, String type) {
+        this.armorType = armorType;
+        this.hpPerTon = hpPerTon;
+        this.type = type;
+    }
+
+    public String getArmorType() {
+        return armorType;
+    }
+
+    public int getHpPerTon() {
+        return hpPerTon;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Calculates total HP for a given tonnage
+     */
+    public int calculateTotalHp(double tonnage) {
+        return (int) (hpPerTon * tonnage);
+    }
+
+    /**
+     * Calculates required tonnage for desired HP
+     */
+    public double calculateRequiredTonnage(int desiredHp) {
+        return (double) desiredHp / hpPerTon;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s (%s) - %d HP/Ton", armorType, type, hpPerTon);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        ArmorType armorType1 = (ArmorType) obj;
+        return hpPerTon == armorType1.hpPerTon &&
+               armorType.equals(armorType1.armorType) &&
+               type.equals(armorType1.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(armorType, hpPerTon, type);
+    }
+}

--- a/src/main/java/com/mechbuilder/model/Shield.java
+++ b/src/main/java/com/mechbuilder/model/Shield.java
@@ -1,0 +1,106 @@
+package com.mechbuilder.model;
+
+/**
+ * Represents a shield system with its specifications.
+ * Loaded from Shields.csv
+ */
+public class Shield {
+    private final String shield;
+    private final int hp;
+    private final int rechargeRate;
+    private final int rechargeDelay;
+    private final double tonnage;
+    private final int heatGenerated;
+    private final int rechargingHeat;
+
+    public Shield(String shield, int hp, int rechargeRate, int rechargeDelay, 
+                  double tonnage, int heatGenerated, int rechargingHeat) {
+        this.shield = shield;
+        this.hp = hp;
+        this.rechargeRate = rechargeRate;
+        this.rechargeDelay = rechargeDelay;
+        this.tonnage = tonnage;
+        this.heatGenerated = heatGenerated;
+        this.rechargingHeat = rechargingHeat;
+    }
+
+    public String getShield() {
+        return shield;
+    }
+
+    public int getHp() {
+        return hp;
+    }
+
+    public int getRechargeRate() {
+        return rechargeRate;
+    }
+
+    public int getRechargeDelay() {
+        return rechargeDelay;
+    }
+
+    public double getTonnage() {
+        return tonnage;
+    }
+
+    public int getHeatGenerated() {
+        return heatGenerated;
+    }
+
+    public int getRechargingHeat() {
+        return rechargingHeat;
+    }
+
+    /**
+     * Calculates time to fully recharge from empty (in seconds)
+     */
+    public double getFullRechargeTime() {
+        if (rechargeRate <= 0) return Double.POSITIVE_INFINITY;
+        return rechargeDelay + ((double) hp / rechargeRate);
+    }
+
+    /**
+     * Calculates efficiency rating (HP per ton)
+     */
+    public double getEfficiencyRating() {
+        if (tonnage <= 0) return 0;
+        return hp / tonnage;
+    }
+
+    /**
+     * Checks if this is a "None" shield (no shield equipped)
+     */
+    public boolean isNoneShield() {
+        return "None".equals(shield);
+    }
+
+    @Override
+    public String toString() {
+        if (isNoneShield()) {
+            return "No Shield";
+        }
+        return String.format("%s - %d HP, %.1ft, %d heat", 
+                           shield, hp, tonnage, heatGenerated);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        Shield shieldObj = (Shield) obj;
+        return hp == shieldObj.hp &&
+               rechargeRate == shieldObj.rechargeRate &&
+               rechargeDelay == shieldObj.rechargeDelay &&
+               Double.compare(shieldObj.tonnage, tonnage) == 0 &&
+               heatGenerated == shieldObj.heatGenerated &&
+               rechargingHeat == shieldObj.rechargingHeat &&
+               shield.equals(shieldObj.shield);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(shield, hp, rechargeRate, rechargeDelay, 
+                                     tonnage, heatGenerated, rechargingHeat);
+    }
+}

--- a/src/test/java/com/mechbuilder/data/ArmorTypeRepositoryTest.java
+++ b/src/test/java/com/mechbuilder/data/ArmorTypeRepositoryTest.java
@@ -1,0 +1,197 @@
+package com.mechbuilder.data;
+
+import com.mechbuilder.model.ArmorType;
+import com.opencsv.exceptions.CsvValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArmorTypeRepositoryTest {
+    
+    private ArmorTypeRepository repository;
+    private List<ArmorType> armorTypes;
+    
+    @BeforeEach
+    void setUp() throws IOException, CsvValidationException {
+        repository = new ArmorTypeRepository();
+        armorTypes = repository.loadAll(); // Load actual production data
+    }
+    
+    @Test
+    void testLoadAllArmorTypesFromProductionData() {
+        // Given: Production CSV data
+        
+        // When: Loading all armor types
+        // Then: Should load armor data successfully
+        assertNotNull(armorTypes);
+        assertTrue(armorTypes.size() > 0, "Should load at least one armor type");
+        
+        // Verify first armor type has required fields
+        ArmorType firstArmor = armorTypes.get(0);
+        assertNotNull(firstArmor.getArmorType(), "Armor should have name");
+        assertNotNull(firstArmor.getType(), "Armor should have type");
+        assertTrue(firstArmor.getHpPerTon() > 0, "HP per ton should be positive");
+    }
+    
+    @Test
+    void testFindArmorByNameExists() throws IOException, CsvValidationException {
+        // Given: Loaded armor data
+        if (!armorTypes.isEmpty()) {
+            String firstArmorName = armorTypes.get(0).getArmorType();
+            
+            // When: Searching by exact name
+            Optional<ArmorType> found = repository.findByName(firstArmorName);
+            
+            // Then: Should find the armor
+            assertTrue(found.isPresent(), "Should find armor by exact name");
+            assertEquals(firstArmorName, found.get().getArmorType());
+        }
+    }
+    
+    @Test
+    void testFindArmorByNameNotExists() throws IOException, CsvValidationException {
+        // Given: Loaded armor data
+        
+        // When: Searching for non-existent armor
+        Optional<ArmorType> found = repository.findByName("NonexistentArmor");
+        
+        // Then: Should not find anything
+        assertFalse(found.isPresent(), "Should not find non-existent armor");
+    }
+    
+    @Test
+    void testFindArmorByType() throws IOException, CsvValidationException {
+        // Given: Loaded armor data
+        
+        // When: Searching for armor by type
+        List<ArmorType> plateArmors = repository.findByType("Plate");
+        List<ArmorType> refractiveArmors = repository.findByType("Refractive");
+        List<ArmorType> ablativeArmors = repository.findByType("Ablative");
+        
+        // Then: Should find armors of each type
+        assertNotNull(plateArmors);
+        assertNotNull(refractiveArmors);
+        assertNotNull(ablativeArmors);
+        
+        // Verify all returned armors match the requested type
+        for (ArmorType armor : plateArmors) {
+            assertEquals("Plate", armor.getType(), "All plate armors should have Plate type");
+        }
+        
+        for (ArmorType armor : refractiveArmors) {
+            assertEquals("Refractive", armor.getType(), "All refractive armors should have Refractive type");
+        }
+        
+        for (ArmorType armor : ablativeArmors) {
+            assertEquals("Ablative", armor.getType(), "All ablative armors should have Ablative type");
+        }
+    }
+    
+    @Test
+    void testFindArmorByHpPerTonRange() throws IOException, CsvValidationException {
+        // Given: Loaded armor data
+        
+        // When: Searching for armor in HP/Ton range
+        List<ArmorType> lowTierArmors = repository.findByHpPerTonRange(30, 50);
+        List<ArmorType> highTierArmors = repository.findByHpPerTonRange(70, 100);
+        
+        // Then: Should find armors in the specified ranges
+        assertNotNull(lowTierArmors);
+        assertNotNull(highTierArmors);
+        
+        // Verify all returned armors are within the specified range
+        for (ArmorType armor : lowTierArmors) {
+            assertTrue(armor.getHpPerTon() >= 30 && armor.getHpPerTon() <= 50,
+                "Low tier armor HP/Ton should be between 30-50, was: " + armor.getHpPerTon());
+        }
+        
+        for (ArmorType armor : highTierArmors) {
+            assertTrue(armor.getHpPerTon() >= 70 && armor.getHpPerTon() <= 100,
+                "High tier armor HP/Ton should be between 70-100, was: " + armor.getHpPerTon());
+        }
+    }
+    
+    @Test
+    void testGetBestArmorByType() throws IOException, CsvValidationException {
+        // Given: Loaded armor data
+        
+        // When: Getting best armor by type
+        Optional<ArmorType> bestPlate = repository.getBestArmorByType("Plate");
+        Optional<ArmorType> bestRefractive = repository.getBestArmorByType("Refractive");
+        Optional<ArmorType> bestAblative = repository.getBestArmorByType("Ablative");
+        
+        // Then: Should find best armors (if any exist for each type)
+        if (bestPlate.isPresent()) {
+            assertEquals("Plate", bestPlate.get().getType());
+            
+            // Verify it's actually the best Plate armor
+            List<ArmorType> allPlateArmors = repository.findByType("Plate");
+            int maxPlateHp = allPlateArmors.stream()
+                    .mapToInt(ArmorType::getHpPerTon)
+                    .max()
+                    .orElse(0);
+            assertEquals(maxPlateHp, bestPlate.get().getHpPerTon());
+        }
+        
+        if (bestAblative.isPresent()) {
+            assertEquals("Ablative", bestAblative.get().getType());
+            
+            // Verify it's actually the best Ablative armor
+            List<ArmorType> allAblativeArmors = repository.findByType("Ablative");
+            int maxAblativeHp = allAblativeArmors.stream()
+                    .mapToInt(ArmorType::getHpPerTon)
+                    .max()
+                    .orElse(0);
+            assertEquals(maxAblativeHp, bestAblative.get().getHpPerTon());
+        }
+    }
+    
+    @Test
+    void testArmorDataIntegrity() {
+        // Given: Loaded armor data
+        
+        // When/Then: Verify data integrity
+        for (ArmorType armor : armorTypes) {
+            // Name should not be null or empty
+            assertNotNull(armor.getArmorType(), "Armor name should not be null");
+            assertFalse(armor.getArmorType().trim().isEmpty(), "Armor name should not be empty");
+            
+            // Type should be valid
+            assertNotNull(armor.getType(), "Armor type should not be null");
+            assertTrue(List.of("Plate", "Refractive", "Ablative").contains(armor.getType()),
+                "Armor type should be one of: Plate, Refractive, Ablative. Was: " + armor.getType());
+            
+            // HP per ton should be reasonable
+            assertTrue(armor.getHpPerTon() > 0 && armor.getHpPerTon() <= 200,
+                "HP per ton should be reasonable (1-200) for " + armor.getArmorType() + 
+                ", was: " + armor.getHpPerTon());
+        }
+    }
+    
+    @Test
+    void testArmorTypeCalculations() throws IOException, CsvValidationException {
+        // Given: A known armor type
+        Optional<ArmorType> armorOpt = repository.findByName("MACM");
+        
+        if (armorOpt.isPresent()) {
+            ArmorType armor = armorOpt.get();
+            
+            // When: Calculating total HP for tonnage
+            int totalHp = armor.calculateTotalHp(5.0);
+            
+            // Then: Should calculate correctly
+            assertEquals(armor.getHpPerTon() * 5, totalHp);
+            
+            // When: Calculating required tonnage for HP
+            double requiredTonnage = armor.calculateRequiredTonnage(150);
+            
+            // Then: Should calculate correctly
+            assertEquals(150.0 / armor.getHpPerTon(), requiredTonnage, 0.001);
+        }
+    }
+}

--- a/src/test/java/com/mechbuilder/data/ShieldRepositoryTest.java
+++ b/src/test/java/com/mechbuilder/data/ShieldRepositoryTest.java
@@ -1,0 +1,249 @@
+package com.mechbuilder.data;
+
+import com.mechbuilder.model.Shield;
+import com.opencsv.exceptions.CsvValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShieldRepositoryTest {
+    
+    private ShieldRepository repository;
+    private List<Shield> shields;
+    
+    @BeforeEach
+    void setUp() throws IOException, CsvValidationException {
+        repository = new ShieldRepository();
+        shields = repository.loadAll(); // Load actual production data
+    }
+    
+    @Test
+    void testLoadAllShieldsFromProductionData() {
+        // Given: Production CSV data
+        
+        // When: Loading all shields
+        // Then: Should load shield data successfully
+        assertNotNull(shields);
+        assertTrue(shields.size() > 0, "Should load at least one shield");
+        
+        // Verify first shield has required fields
+        Shield firstShield = shields.get(0);
+        assertNotNull(firstShield.getShield(), "Shield should have name");
+        assertTrue(firstShield.getHp() >= 0, "HP should be non-negative");
+        assertTrue(firstShield.getTonnage() >= 0, "Tonnage should be non-negative");
+        assertTrue(firstShield.getRechargeRate() >= 0, "Recharge rate should be non-negative");
+    }
+    
+    @Test
+    void testFindShieldByNameExists() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        if (!shields.isEmpty()) {
+            String firstShieldName = shields.get(0).getShield();
+            
+            // When: Searching by exact name
+            Optional<Shield> found = repository.findByName(firstShieldName);
+            
+            // Then: Should find the shield
+            assertTrue(found.isPresent(), "Should find shield by exact name");
+            assertEquals(firstShieldName, found.get().getShield());
+        }
+    }
+    
+    @Test
+    void testFindShieldByNameNotExists() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Searching for non-existent shield
+        Optional<Shield> found = repository.findByName("NonexistentShield");
+        
+        // Then: Should not find anything
+        assertFalse(found.isPresent(), "Should not find non-existent shield");
+    }
+    
+    @Test
+    void testFindShieldsByTonnageRange() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Searching for shields in tonnage range
+        List<Shield> lightShields = repository.findByTonnageRange(0, 4);
+        List<Shield> mediumShields = repository.findByTonnageRange(4, 6);
+        
+        // Then: Should find shields in the specified ranges
+        assertNotNull(lightShields);
+        assertNotNull(mediumShields);
+        
+        // Verify all returned shields are within the specified range
+        for (Shield shield : lightShields) {
+            assertTrue(shield.getTonnage() >= 0 && shield.getTonnage() <= 4,
+                "Light shield tonnage should be 0-4, was: " + shield.getTonnage());
+        }
+        
+        for (Shield shield : mediumShields) {
+            assertTrue(shield.getTonnage() >= 4 && shield.getTonnage() <= 6,
+                "Medium shield tonnage should be 4-6, was: " + shield.getTonnage());
+        }
+    }
+    
+    @Test
+    void testFindShieldsByHpRange() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Searching for shields in HP range
+        List<Shield> lowHpShields = repository.findByHpRange(0, 200);
+        List<Shield> highHpShields = repository.findByHpRange(300, 600);
+        
+        // Then: Should find shields in the specified ranges
+        assertNotNull(lowHpShields);
+        assertNotNull(highHpShields);
+        
+        // Verify all returned shields are within the specified range
+        for (Shield shield : lowHpShields) {
+            assertTrue(shield.getHp() >= 0 && shield.getHp() <= 200,
+                "Low HP shield should be 0-200 HP, was: " + shield.getHp());
+        }
+        
+        for (Shield shield : highHpShields) {
+            assertTrue(shield.getHp() >= 300 && shield.getHp() <= 600,
+                "High HP shield should be 300-600 HP, was: " + shield.getHp());
+        }
+    }
+    
+    @Test
+    void testFindActualShields() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Getting actual shields (excluding "None")
+        List<Shield> actualShields = repository.findActualShields();
+        
+        // Then: Should exclude "None" shield
+        assertNotNull(actualShields);
+        
+        for (Shield shield : actualShields) {
+            assertFalse(shield.isNoneShield(), "Actual shields should not include 'None' option");
+            assertNotEquals("None", shield.getShield(), "Shield name should not be 'None'");
+        }
+    }
+    
+    @Test
+    void testGetMostEfficientShield() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Getting most efficient shield
+        Optional<Shield> mostEfficient = repository.getMostEfficientShield();
+        
+        // Then: Should find a shield (if any actual shields exist)
+        List<Shield> actualShields = repository.findActualShields();
+        if (!actualShields.isEmpty()) {
+            assertTrue(mostEfficient.isPresent(), "Should find most efficient shield when actual shields exist");
+            
+            Shield efficient = mostEfficient.get();
+            assertFalse(efficient.isNoneShield(), "Most efficient shield should not be 'None'");
+            
+            // Verify it's actually the most efficient
+            double maxEfficiency = actualShields.stream()
+                    .mapToDouble(Shield::getEfficiencyRating)
+                    .max()
+                    .orElse(0);
+            assertEquals(maxEfficiency, efficient.getEfficiencyRating(), 0.001,
+                "Should be the actual most efficient shield");
+        }
+    }
+    
+    @Test
+    void testFindShieldsByEfficiency() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Getting shields sorted by efficiency
+        List<Shield> shieldsByEfficiency = repository.findShieldsByEfficiency();
+        
+        // Then: Should be sorted in descending order of efficiency
+        assertNotNull(shieldsByEfficiency);
+        
+        for (int i = 0; i < shieldsByEfficiency.size() - 1; i++) {
+            Shield current = shieldsByEfficiency.get(i);
+            Shield next = shieldsByEfficiency.get(i + 1);
+            
+            assertTrue(current.getEfficiencyRating() >= next.getEfficiencyRating(),
+                "Shields should be sorted by efficiency (descending): " +
+                current.getEfficiencyRating() + " >= " + next.getEfficiencyRating());
+        }
+        
+        // Should not include "None" shields
+        for (Shield shield : shieldsByEfficiency) {
+            assertFalse(shield.isNoneShield(), "Efficiency list should not include 'None' shields");
+        }
+    }
+    
+    @Test
+    void testShieldDataIntegrity() {
+        // Given: Loaded shield data
+        
+        // When/Then: Verify data integrity
+        for (Shield shield : shields) {
+            // Name should not be null or empty
+            assertNotNull(shield.getShield(), "Shield name should not be null");
+            assertFalse(shield.getShield().trim().isEmpty(), "Shield name should not be empty");
+            
+            // All numeric values should be non-negative
+            assertTrue(shield.getHp() >= 0, "HP should be non-negative for " + shield.getShield());
+            assertTrue(shield.getRechargeRate() >= 0, "Recharge rate should be non-negative for " + shield.getShield());
+            assertTrue(shield.getRechargeDelay() >= 0, "Recharge delay should be non-negative for " + shield.getShield());
+            assertTrue(shield.getTonnage() >= 0, "Tonnage should be non-negative for " + shield.getShield());
+            assertTrue(shield.getHeatGenerated() >= 0, "Heat generated should be non-negative for " + shield.getShield());
+            assertTrue(shield.getRechargingHeat() >= 0, "Recharging heat should be non-negative for " + shield.getShield());
+            
+            // Reasonable value ranges
+            assertTrue(shield.getHp() <= 1000, "HP should be reasonable (≤1000) for " + shield.getShield());
+            assertTrue(shield.getTonnage() <= 20, "Tonnage should be reasonable (≤20) for " + shield.getShield());
+            assertTrue(shield.getRechargeRate() <= 100, "Recharge rate should be reasonable (≤100) for " + shield.getShield());
+        }
+    }
+    
+    @Test
+    void testShieldCalculations() throws IOException, CsvValidationException {
+        // Given: A known shield
+        Optional<Shield> shieldOpt = repository.findByName("Aegis Class Barrier");
+        
+        if (shieldOpt.isPresent()) {
+            Shield shield = shieldOpt.get();
+            
+            // When: Calculating full recharge time
+            double rechargeTime = shield.getFullRechargeTime();
+            
+            // Then: Should calculate correctly
+            if (shield.getRechargeRate() > 0) {
+                double expectedTime = shield.getRechargeDelay() + ((double) shield.getHp() / shield.getRechargeRate());
+                assertEquals(expectedTime, rechargeTime, 0.001, "Recharge time calculation should be correct");
+            }
+            
+            // When: Calculating efficiency rating
+            double efficiency = shield.getEfficiencyRating();
+            
+            // Then: Should calculate correctly
+            if (shield.getTonnage() > 0) {
+                double expectedEfficiency = shield.getHp() / shield.getTonnage();
+                assertEquals(expectedEfficiency, efficiency, 0.001, "Efficiency calculation should be correct");
+            }
+        }
+    }
+    
+    @Test
+    void testNoneShieldIdentification() throws IOException, CsvValidationException {
+        // Given: Loaded shield data
+        
+        // When: Looking for "None" shield
+        Optional<Shield> noneShield = repository.findByName("None");
+        
+        // Then: Should identify it correctly if it exists
+        if (noneShield.isPresent()) {
+            assertTrue(noneShield.get().isNoneShield(), "'None' shield should be identified as none shield");
+            assertEquals(0, noneShield.get().getHp(), "None shield should have 0 HP");
+            assertEquals(0, noneShield.get().getTonnage(), 0.001, "None shield should have 0 tonnage");
+        }
+    }
+}

--- a/src/test/java/com/mechbuilder/model/ArmorTypeTest.java
+++ b/src/test/java/com/mechbuilder/model/ArmorTypeTest.java
@@ -1,0 +1,156 @@
+package com.mechbuilder.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArmorTypeTest {
+    
+    private ArmorType plateArmor;
+    private ArmorType refractiveArmor;
+    private ArmorType ablativeArmor;
+    
+    @BeforeEach
+    void setUp() {
+        plateArmor = new ArmorType("TKM", 45, "Plate");
+        refractiveArmor = new ArmorType("ARP", 45, "Refractive");
+        ablativeArmor = new ArmorType("KS MIV", 100, "Ablative");
+    }
+    
+    @Test
+    void testArmorTypeConstruction() {
+        // Given: ArmorType constructor parameters
+        String name = "Test Armor";
+        int hpPerTon = 50;
+        String type = "Plate";
+        
+        // When: Creating ArmorType
+        ArmorType armor = new ArmorType(name, hpPerTon, type);
+        
+        // Then: Should set all properties correctly
+        assertEquals(name, armor.getArmorType());
+        assertEquals(hpPerTon, armor.getHpPerTon());
+        assertEquals(type, armor.getType());
+    }
+    
+    @Test
+    void testCalculateTotalHp() {
+        // Given: ArmorType with known HP/Ton
+        
+        // When: Calculating total HP for different tonnages
+        int hp1 = plateArmor.calculateTotalHp(1.0);
+        int hp2 = plateArmor.calculateTotalHp(2.5);
+        int hp0 = plateArmor.calculateTotalHp(0.0);
+        
+        // Then: Should calculate correctly
+        assertEquals(45, hp1, "1 ton should give 45 HP");
+        assertEquals(112, hp2, "2.5 tons should give 112 HP (45 * 2.5 = 112.5, truncated to 112)");
+        assertEquals(0, hp0, "0 tons should give 0 HP");
+    }
+    
+    @Test
+    void testCalculateRequiredTonnage() {
+        // Given: ArmorType with known HP/Ton
+        
+        // When: Calculating required tonnage for different HP values
+        double tonnage1 = plateArmor.calculateRequiredTonnage(45);
+        double tonnage2 = plateArmor.calculateRequiredTonnage(90);
+        double tonnage3 = plateArmor.calculateRequiredTonnage(0);
+        double tonnage4 = ablativeArmor.calculateRequiredTonnage(500);
+        
+        // Then: Should calculate correctly
+        assertEquals(1.0, tonnage1, 0.001, "45 HP should require 1 ton");
+        assertEquals(2.0, tonnage2, 0.001, "90 HP should require 2 tons");
+        assertEquals(0.0, tonnage3, 0.001, "0 HP should require 0 tons");
+        assertEquals(5.0, tonnage4, 0.001, "500 HP with 100 HP/ton should require 5 tons");
+    }
+    
+    @Test
+    void testToString() {
+        // Given: ArmorType instances
+        
+        // When: Converting to string
+        String plateString = plateArmor.toString();
+        String ablativeString = ablativeArmor.toString();
+        
+        // Then: Should format correctly
+        assertEquals("TKM (Plate) - 45 HP/Ton", plateString);
+        assertEquals("KS MIV (Ablative) - 100 HP/Ton", ablativeString);
+    }
+    
+    @Test
+    void testEquals() {
+        // Given: ArmorType instances
+        ArmorType samePlateArmor = new ArmorType("TKM", 45, "Plate");
+        ArmorType differentArmor = new ArmorType("Different", 30, "Plate");
+        
+        // When/Then: Testing equality
+        assertEquals(plateArmor, samePlateArmor, "Same armor types should be equal");
+        assertNotEquals(plateArmor, differentArmor, "Different armor types should not be equal");
+        assertNotEquals(plateArmor, null, "Armor should not equal null");
+        assertNotEquals(plateArmor, "not an armor", "Armor should not equal different object type");
+    }
+    
+    @Test
+    void testHashCode() {
+        // Given: ArmorType instances
+        ArmorType samePlateArmor = new ArmorType("TKM", 45, "Plate");
+        
+        // When/Then: Testing hash code consistency
+        assertEquals(plateArmor.hashCode(), samePlateArmor.hashCode(), 
+            "Equal armor types should have same hash code");
+    }
+    
+    @Test
+    void testArmorTypeComparison() {
+        // Given: Different armor types
+        
+        // When: Comparing efficiency
+        // Then: Ablative should be most efficient
+        assertTrue(ablativeArmor.getHpPerTon() > plateArmor.getHpPerTon(),
+            "Ablative armor should be more efficient than plate");
+        assertTrue(ablativeArmor.getHpPerTon() > refractiveArmor.getHpPerTon(),
+            "Ablative armor should be more efficient than refractive");
+        
+        // Plate and refractive have same HP/ton in this test case
+        assertEquals(plateArmor.getHpPerTon(), refractiveArmor.getHpPerTon(),
+            "These specific plate and refractive armors have same efficiency");
+    }
+    
+    @Test
+    void testArmorTypeEfficiencyCalculations() {
+        // Given: Different scenarios
+        
+        // When: Calculating for large tonnage values
+        int massiveHp = ablativeArmor.calculateTotalHp(100.0);
+        
+        // Then: Should handle large values correctly
+        assertEquals(10000, massiveHp, "100 tons of 100 HP/ton armor should give 10,000 HP");
+        
+        // When: Calculating fractional tonnage requirements
+        double fractionalTonnage = ablativeArmor.calculateRequiredTonnage(150);
+        
+        // Then: Should handle fractions correctly
+        assertEquals(1.5, fractionalTonnage, 0.001, "150 HP should require 1.5 tons of 100 HP/ton armor");
+    }
+    
+    @Test
+    void testEdgeCases() {
+        // Given: Edge case values
+        ArmorType zeroHpArmor = new ArmorType("Zero", 0, "Test");
+        
+        // When: Calculating with zero HP/ton
+        double infiniteTonnage = zeroHpArmor.calculateRequiredTonnage(100);
+        
+        // Then: Should handle division by zero
+        assertEquals(Double.POSITIVE_INFINITY, infiniteTonnage, 
+            "Requiring HP from 0 HP/ton armor should result in infinite tonnage");
+        
+        // When: Calculating HP with zero tonnage
+        int zeroHp = plateArmor.calculateTotalHp(0.0);
+        
+        // Then: Should return zero
+        assertEquals(0, zeroHp, "Zero tonnage should give zero HP");
+    }
+}

--- a/src/test/java/com/mechbuilder/model/ShieldTest.java
+++ b/src/test/java/com/mechbuilder/model/ShieldTest.java
@@ -1,0 +1,201 @@
+package com.mechbuilder.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShieldTest {
+    
+    private Shield aegisShield;
+    private Shield bastionShield;
+    private Shield noneShield;
+    private Shield umbraShield;
+    
+    @BeforeEach
+    void setUp() {
+        aegisShield = new Shield("Aegis Class Barrier", 500, 25, 5, 6.0, 20, 2);
+        bastionShield = new Shield("Bastion Wave Repeater", 300, 60, 5, 5.0, 12, 6);
+        noneShield = new Shield("None", 0, 0, 0, 0.0, 0, 0);
+        umbraShield = new Shield("Umbra Phase Curtain", 60, 10, 0, 4.0, 3, 30);
+    }
+    
+    @Test
+    void testShieldConstruction() {
+        // Given: Shield constructor parameters
+        String name = "Test Shield";
+        int hp = 400;
+        int rechargeRate = 30;
+        int rechargeDelay = 3;
+        double tonnage = 5.5;
+        int heatGenerated = 15;
+        int rechargingHeat = 8;
+        
+        // When: Creating Shield
+        Shield shield = new Shield(name, hp, rechargeRate, rechargeDelay, tonnage, heatGenerated, rechargingHeat);
+        
+        // Then: Should set all properties correctly
+        assertEquals(name, shield.getShield());
+        assertEquals(hp, shield.getHp());
+        assertEquals(rechargeRate, shield.getRechargeRate());
+        assertEquals(rechargeDelay, shield.getRechargeDelay());
+        assertEquals(tonnage, shield.getTonnage(), 0.001);
+        assertEquals(heatGenerated, shield.getHeatGenerated());
+        assertEquals(rechargingHeat, shield.getRechargingHeat());
+    }
+    
+    @Test
+    void testGetFullRechargeTime() {
+        // Given: Shield instances with different recharge characteristics
+        
+        // When: Calculating full recharge time
+        double aegisRechargeTime = aegisShield.getFullRechargeTime();
+        double bastionRechargeTime = bastionShield.getFullRechargeTime();
+        double umbraRechargeTime = umbraShield.getFullRechargeTime();
+        double noneRechargeTime = noneShield.getFullRechargeTime();
+        
+        // Then: Should calculate correctly
+        // Aegis: delay=5, hp=500, rate=25 -> 5 + (500/25) = 5 + 20 = 25
+        assertEquals(25.0, aegisRechargeTime, 0.001, "Aegis should take 25 seconds to fully recharge");
+        
+        // Bastion: delay=5, hp=300, rate=60 -> 5 + (300/60) = 5 + 5 = 10
+        assertEquals(10.0, bastionRechargeTime, 0.001, "Bastion should take 10 seconds to fully recharge");
+        
+        // Umbra: delay=0, hp=60, rate=10 -> 0 + (60/10) = 0 + 6 = 6
+        assertEquals(6.0, umbraRechargeTime, 0.001, "Umbra should take 6 seconds to fully recharge");
+        
+        // None: rate=0 -> should be infinite
+        assertEquals(Double.POSITIVE_INFINITY, noneRechargeTime, "None shield should have infinite recharge time");
+    }
+    
+    @Test
+    void testGetEfficiencyRating() {
+        // Given: Shield instances with different tonnage
+        
+        // When: Calculating efficiency rating (HP per ton)
+        double aegisEfficiency = aegisShield.getEfficiencyRating();
+        double bastionEfficiency = bastionShield.getEfficiencyRating();
+        double noneEfficiency = noneShield.getEfficiencyRating();
+        
+        // Then: Should calculate correctly
+        // Aegis: 500 HP / 6 tons = 83.333...
+        assertEquals(500.0/6.0, aegisEfficiency, 0.001, "Aegis efficiency should be ~83.33 HP/ton");
+        
+        // Bastion: 300 HP / 5 tons = 60
+        assertEquals(60.0, bastionEfficiency, 0.001, "Bastion efficiency should be 60 HP/ton");
+        
+        // None: 0 HP / 0 tons = 0 (special case)
+        assertEquals(0.0, noneEfficiency, 0.001, "None shield efficiency should be 0");
+    }
+    
+    @Test
+    void testIsNoneShield() {
+        // Given: Shield instances
+        
+        // When/Then: Testing none shield identification
+        assertTrue(noneShield.isNoneShield(), "Shield named 'None' should be identified as none shield");
+        assertFalse(aegisShield.isNoneShield(), "Aegis shield should not be identified as none shield");
+        assertFalse(bastionShield.isNoneShield(), "Bastion shield should not be identified as none shield");
+        
+        // Test case sensitivity
+        Shield caseTestShield = new Shield("none", 0, 0, 0, 0.0, 0, 0);
+        assertFalse(caseTestShield.isNoneShield(), "Should be case sensitive - 'none' != 'None'");
+    }
+    
+    @Test
+    void testToString() {
+        // Given: Shield instances
+        
+        // When: Converting to string
+        String aegisString = aegisShield.toString();
+        String noneString = noneShield.toString();
+        
+        // Then: Should format correctly
+        assertEquals("Aegis Class Barrier - 500 HP, 6.0t, 20 heat", aegisString);
+        assertEquals("No Shield", noneString);
+    }
+    
+    @Test
+    void testEquals() {
+        // Given: Shield instances
+        Shield sameAegis = new Shield("Aegis Class Barrier", 500, 25, 5, 6.0, 20, 2);
+        Shield differentShield = new Shield("Different Shield", 400, 20, 3, 5.0, 15, 5);
+        
+        // When/Then: Testing equality
+        assertEquals(aegisShield, sameAegis, "Same shields should be equal");
+        assertNotEquals(aegisShield, differentShield, "Different shields should not be equal");
+        assertNotEquals(aegisShield, null, "Shield should not equal null");
+        assertNotEquals(aegisShield, "not a shield", "Shield should not equal different object type");
+    }
+    
+    @Test
+    void testHashCode() {
+        // Given: Shield instances
+        Shield sameAegis = new Shield("Aegis Class Barrier", 500, 25, 5, 6.0, 20, 2);
+        
+        // When/Then: Testing hash code consistency
+        assertEquals(aegisShield.hashCode(), sameAegis.hashCode(), 
+            "Equal shields should have same hash code");
+    }
+    
+    @Test
+    void testShieldEfficiencyComparison() {
+        // Given: Different shields
+        
+        // When: Comparing efficiency ratings
+        double aegisEff = aegisShield.getEfficiencyRating();
+        double bastionEff = bastionShield.getEfficiencyRating();
+        double umbraEff = umbraShield.getEfficiencyRating();
+        
+        // Then: Should allow comparison
+        // Aegis: 500/6 = ~83.33, Bastion: 300/5 = 60, Umbra: 60/4 = 15
+        assertTrue(aegisEff > bastionEff, "Aegis should be more efficient than Bastion");
+        assertTrue(bastionEff > umbraEff, "Bastion should be more efficient than Umbra");
+        assertTrue(aegisEff > umbraEff, "Aegis should be more efficient than Umbra");
+    }
+    
+    @Test
+    void testShieldRechargeTimeComparison() {
+        // Given: Different shields
+        
+        // When: Comparing recharge times
+        double aegisTime = aegisShield.getFullRechargeTime();
+        double bastionTime = bastionShield.getFullRechargeTime();
+        double umbraTime = umbraShield.getFullRechargeTime();
+        
+        // Then: Should allow comparison
+        // Aegis: 25s, Bastion: 10s, Umbra: 6s
+        assertTrue(umbraTime < bastionTime, "Umbra should recharge faster than Bastion");
+        assertTrue(bastionTime < aegisTime, "Bastion should recharge faster than Aegis");
+        assertTrue(umbraTime < aegisTime, "Umbra should recharge fastest");
+    }
+    
+    @Test
+    void testEdgeCases() {
+        // Given: Edge case shields
+        Shield zeroRechargeShield = new Shield("Zero Recharge", 100, 0, 5, 3.0, 10, 5);
+        Shield instantRechargeShield = new Shield("Instant", 200, 1000, 0, 4.0, 8, 2);
+        
+        // When: Testing edge cases
+        double zeroRechargeTime = zeroRechargeShield.getFullRechargeTime();
+        double instantRechargeTime = instantRechargeShield.getFullRechargeTime();
+        
+        // Then: Should handle correctly
+        assertEquals(Double.POSITIVE_INFINITY, zeroRechargeTime, 
+            "Zero recharge rate should result in infinite recharge time");
+        assertEquals(0.2, instantRechargeTime, 0.001, 
+            "High recharge rate with no delay should be very fast: 0 + (200/1000) = 0.2");
+    }
+    
+    @Test
+    void testZeroTonnageEfficiency() {
+        // Given: Shield with zero tonnage
+        Shield zeroTonnageShield = new Shield("Zero Tonnage", 100, 10, 2, 0.0, 5, 3);
+        
+        // When: Calculating efficiency
+        double efficiency = zeroTonnageShield.getEfficiencyRating();
+        
+        // Then: Should handle division by zero
+        assertEquals(0.0, efficiency, 0.001, "Zero tonnage shield should have 0 efficiency rating");
+    }
+}


### PR DESCRIPTION
- Add ArmorType model and repository for Armor Types.csv data
- Add Shield model and repository for Shields.csv data
- Add comprehensive test suite for new components (39 tests)
- Add Maven wrapper for consistent builds across environments
- Update README.md to use Maven wrapper commands
- Remove Maven installation requirement from prerequisites
- Clean up obsolete ui-v1 profile references
- Fix .gitignore to properly include Maven wrapper files

All 115 tests passing. Project now self-contained with no external Maven dependency.